### PR TITLE
Use forked version of semver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1395,7 +1395,7 @@ dependencies = [
 
 [[package]]
 name = "tfswitcher"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "clap",
  "dialoguer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1235,11 +1235,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "semver"
-version = "1.0.17"
-source = "git+https://github.com/ASleepyCat/semver?branch=tilde-arrow#5c0f1b6a814b0f3a9a0ac57d9ec1234828bfe8c2"
-
-[[package]]
 name = "serde"
 version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1383,6 +1378,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tf-semver"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62808a5042487d591eaffdfc1b0cae0cf0e08b3c13df526dc306e7e2e9148ee3"
+
+[[package]]
 name = "tfconfig"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1402,8 +1403,8 @@ dependencies = [
  "home",
  "regex",
  "reqwest",
- "semver",
  "tempdir",
+ "tf-semver",
  "tfconfig",
  "zip",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tfswitcher"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["ASleepyCat dyeom340@gmail.com"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,7 @@ dialoguer = "0.10.4"
 home = "0.5.4"
 regex = "1.8.1"
 reqwest = { version = "0.11.16", features = ["json", "blocking"] }
-semver = "1.0.17"
+semver = { version = "1.0.17", package = "tf-semver" }
 tempdir = "0.3.7"
 tfconfig = "0.1.0"
 zip = "0.6.4"
-
-[patch.crates-io]
-semver = { git = "https://github.com/ASleepyCat/semver", branch = "tilde-arrow" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -388,7 +388,7 @@ mod tests {
         let tmp_dir = TempDir::new("test_get_version_from_module")?;
         let file_path = tmp_dir.path().join("version.tf");
         let mut file = File::create(file_path)?;
-        file.write_all(b"terraform { required_version = \"1.0.0\" }")?;
+        file.write_all(b"terraform { required_version = \"~>1.0.0\" }")?;
         let current_dir = env::current_dir()?;
         env::set_current_dir(Path::new(&tmp_dir.path()))?;
 


### PR DESCRIPTION
Fixes `~>` version constraints not working on published versions.