### PR TITLE
Fix caching

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -225,6 +225,7 @@ fn cache_zip_file(zip_name: &str, buffer: &[u8]) {
     match home::home_dir() {
         Some(mut path) => {
             path.push(DEFAULT_CACHE_LOCATION);
+            println!("Caching archive to {path:?}");
             if let Err(e) = fs::create_dir_all(&path) {
                 println!("Unable to cache archive: {e}");
                 return;

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,7 +80,7 @@ fn find_terraform_program_path() -> Option<PathBuf> {
     match home::home_dir() {
         Some(mut path) => {
             path.push(format!("{DEFAULT_LOCATION}/{PROGRAM_NAME}"));
-            println!("Could not locate {PROGRAM_NAME}, installing to {path:?}\nmake sure to include the directory into your $PATH");
+            println!("Could not locate {PROGRAM_NAME}, installing to {path:?}\nMake sure to include the directory into your $PATH");
             Some(path)
         }
         None => None,


### PR DESCRIPTION
Cache files under `~/.cache/tfswitcher` instead, and don't fail installation process when caching process encounters an error.

Fixes #6.